### PR TITLE
fix: add missing case for hover

### DIFF
--- a/debugger/src/internal/debug_bridge.cpp
+++ b/debugger/src/internal/debug_bridge.cpp
@@ -444,6 +444,8 @@ ResponseOrError<EvaluateResponse> DebugBridge::evaluate(
       response = evaluateRepl(request);
     else if (context == "watch")
       response = evaluateWatch(request);
+    else if (context == "hover")
+      response = evaluateHover(request);
     else {
       DEBUGGER_LOG_ERROR("[evaluate] Invalid evaluate context: {}", context);
       response = Error{"Invalid evaluate context"};


### PR DESCRIPTION
I noticed `debug_bridge` was missing a case for the "hover" context. This doesn't seem to cause a problem when using luau-debugger from VS Code, but it leads to errors when using nvim-dap.

I just added the missing case to fix the errors I was seeing.